### PR TITLE
Fix repo reference in gemspec

### DIFF
--- a/simple_ams.gemspec
+++ b/simple_ams.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{ActiveModel Serializers, simplified.}
   spec.description   = %q{ActiveModel Serializers, simplified.}
-  spec.homepage      = "https://github.com/vasilakisfil/simple-ams"
+  spec.homepage      = "https://github.com/vasilakisfil/SimpleAMS"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})


### PR DESCRIPTION
Hey there, somebody submitted your project for the Ruby Toolbox catalog via https://github.com/rubytoolbox/catalog/pull/361, but I noticed the repo reference was broken on the gemspec.

Note that you will have to publish a new version to rubygems.org for the change to be reflected on their API and ruby toolbox to pick it up.

Best,
Christoph