### PR TITLE
Fix serializer inference when collection is not an array

### DIFF
--- a/lib/simple_ams/options.rb
+++ b/lib/simple_ams/options.rb
@@ -316,7 +316,7 @@ module SimpleAMS
 
       def infer_serializer
         namespace = _internal[:module] ? "#{_internal[:module]}::" : ""
-        resource_klass = resource.kind_of?(Array) ? resource[0].class : resource.class
+        resource_klass = resource.respond_to?(:to_a) && resource.respond_to?(:last) ? resource[0].class : resource.class
         if resource_klass == NilClass
           return EmptySerializer
         else

--- a/spec/options/collection_spec.rb
+++ b/spec/options/collection_spec.rb
@@ -88,4 +88,36 @@ RSpec.describe SimpleAMS::Options, 'collection' do
       expect(links_got.map(&:options)).to eq(links_expected.map(&:options))
     end
   end
+
+  context "when collection is not an array" do
+    let(:collection) do
+      Class.new do
+        def initialize(arr)
+          @arr = arr
+        end
+
+        def to_a
+          @arr
+        end
+
+        def [](index)
+          @arr[index]
+        end
+
+        def first
+          @arr.first
+        end
+
+        def last
+          @arr.last
+        end
+      end.new([User.new])
+    end
+
+    let(:options) { SimpleAMS::Options.new(collection) }
+
+    it "infers serialier class correctly" do
+      expect(options.serializer_class).to eq UserSerializer
+    end
+  end
 end


### PR DESCRIPTION
It allows serializer inference to work correctly with non-array collections (e.g. ActiveRecord::Relation). Check for `#to_a` and `#last` seems enough to determine that object is really a collection. It also should work with `Set`.